### PR TITLE
Update rails_search.yml

### DIFF
--- a/catalog/Active_Record_Plugins/rails_search.yml
+++ b/catalog/Active_Record_Plugins/rails_search.yml
@@ -12,6 +12,7 @@ projects:
   - elasticsearch-rails
   - elastictastic
   - ferret
+  - forty_facets
   - pg_search
   - redis-search
   - rsolr


### PR DESCRIPTION
This adds the [forty_facets](https://www.ruby-toolbox.com/projects/forty_facets) gem to the search category.

**Before submitting your pull request:**

- [x] If you're referencing a gem by its GitHub repository (e.g. `rails/rails`), please verify
      that it is _not_ packaged as a Ruby gem. (If it _is_ packaged as a gem, please reference it
      by its gem name instead, e.g. `rails`.)
- [x] Please make sure the projects are listed in case-insensitive alphabetical order
- [ ] Make sure the CI build passes, we validate your proposed changes in the test suite :)
